### PR TITLE
Add Welsh amendments

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ How would the yes/no be said if you were answering a simple question?
 |[English](https://en.wikipedia.org/wiki/English_language)|zero|one|two|three|four|five|six|seven|eight|nine|yes|no|YES|
 |[German](https://en.wikipedia.org/wiki/German_language)|null|eins|zwei|drei|vier|fünf|sechs|sieben|acht|neun|ja|nein|YES|
 |[French](https://en.wikipedia.org/wiki/French_language)|zéro|un|deux|trois|quatre|cinq|six|sept|huit|neuf|oui|non|YES|
-|[Welsh](https://en.wikipedia.org/wiki/Welsh_language)||un|dau|tri|pedwar|pump|chwech|saith|wyth|naw|||NO|
+|[Welsh](https://en.wikipedia.org/wiki/Welsh_language)|sero / dim|un|dau|tri|pedwar|pump|chwech|saith|wyth|naw|||YES|
 |[Breton](https://en.wikipedia.org/wiki/Breton_language)|mann|unan|daou|tri|pevar|pemp|c'hwec'h|seizh|eizh|nav|ya|nann|NO|
 |[Chuvash](https://en.wikipedia.org/wiki/Chuvash_language)|||||||||||||NO|
 |[Turkish](https://en.wikipedia.org/wiki/Turkish_language)|sıfır|bir|iki|üç|dört|beş|altı|yedi|sekiz|dokuz|evet|hayır|YES|


### PR DESCRIPTION
_(Background: Welsh is my first language and what I've spent most of my life talking in, throughout school and at home)_

In Welsh, '0' can be "sero" or "dim".

Colloquially "dim" is likely the more common form, especially when talking about years, phone numbers, or decimal digits.

However, "sero" is likely the more correct name for the actual number 0.

I've been debating in my head about which one to write down here, but I couldn't settle on one so I've written both down. This is how it's done on these reference pages:

* https://en.wikipedia.org/wiki/Welsh_numerals (the Welsh version of this article doesn't include 0 - https://cy.wikipedia.org/wiki/Rhifau_yn_y_Gymraeg)
* https://www.omniglot.com/language/numbers/celtic.htm
* https://www.languagesandnumbers.com/how-to-count-in-welsh/en/cym/

I'm not sure if this is acceptable for the document, or whether one form of the number should be settled on, but of course that's what these pull requests are for!

---

On another matter. In Welsh, we don't have single words for "yes" and "no". Agreement and disagreement in Welsh depends on the context of the question being asked - this has been a problem with software localisation in the past when they just have generic "yes" and "no" terms that are used for any contexts.

See https://en.wikibooks.org/wiki/Welsh/Useful_Phrases#Yes_and_No for more information and examples about this.

So I think those columns should either be left empty for Welsh or make use of "Ie / Ia" and "Na" (though those have limited contexts where they make sense).